### PR TITLE
Create customer url link in urls.py

### DIFF
--- a/bangazon/bangazon/urls.py
+++ b/bangazon/bangazon/urls.py
@@ -15,6 +15,7 @@ Including another URLconf
 """
 
 from django.conf.urls import url, include
+from django.contrib import admin
 from rest_framework import routers
 from bangazon_api import views
 

--- a/bangazon/bangazon/urls.py
+++ b/bangazon/bangazon/urls.py
@@ -13,9 +13,15 @@ Including another URLconf
     1. Import the include() function: from django.conf.urls import url, include
     2. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
 """
-from django.conf.urls import url
-from django.contrib import admin
+
+from django.conf.urls import url, include
+from rest_framework import routers
+from bangazon_api import views
+
+router = routers.DefaultRouter()
+router.register(r'customers', views.CustomerViewSet)
 
 urlpatterns = [
-    url(r'^admin/', admin.site.urls),
+    url(r'^', include(router.urls)),
+    url(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework'))
 ]

--- a/bangazon/bangazon/urls.py
+++ b/bangazon/bangazon/urls.py
@@ -24,5 +24,6 @@ router.register(r'customers', views.CustomerViewSet)
 
 urlpatterns = [
     url(r'^', include(router.urls)),
+    url(r'^admin/', admin.site.urls), 
     url(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework'))
 ]


### PR DESCRIPTION
Created a url reference for bangazon_api app in main bangazon project urls.py

## Related Issue
 #51 

## Motivation and Context
This was required because there was no link to our bangazon_api Customer view.

## How Has This Been Tested?
ran the manage.py server, surfed on over to localhost:8000/customers, and received a lovely view!

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
