### PR TITLE
updated author names in docstring from full names to github acct names

### DIFF
--- a/bangazon/bangazon_api/serializers.py
+++ b/bangazon/bangazon_api/serializers.py
@@ -43,7 +43,7 @@ class OrderSerializer(serializers.HyperlinkedModelSerializer):
 class ProductSerializer(serializers.HyperlinkedModelSerializer):
     """
     Hyperlinked Serializer for the Product Model.
-    -Danielle Adkins
+    @itsdanirenae
     """
     class Meta:
         model = Product
@@ -53,7 +53,7 @@ class ProductSerializer(serializers.HyperlinkedModelSerializer):
 class CustomerSerializer(serializers.HyperlinkedModelSerializer):
     """
     Hyperlinked Serializer for the Customer Model.
-    -Matthew McCord
+    @mccordgh
     """
     class Meta:
         model = Customer


### PR DESCRIPTION
## Related Issue
 #57 

## Motivation and Context
Author names were inconsistent in the serializers docstrings, so I updated them to be consistent as github accounts instead of full names.