### PR TITLE
Rw prod types view

### DIFF
--- a/bangazon/bangazon/urls.py
+++ b/bangazon/bangazon/urls.py
@@ -8,6 +8,7 @@ router.register(r'products', views.ProductViewSet)
 router.register(r'customers', views.CustomerViewSet)
 router.register(r'orders', views.OrderViewSet)
 router.register(r'PaymentType', views.PaymentTypeViewSet)
+router.register(r'productType', views.ProductTypeViewSet)
 
 
 urlpatterns = [

--- a/bangazon/bangazon_api/serializers.py
+++ b/bangazon/bangazon_api/serializers.py
@@ -24,7 +24,7 @@ class ProductTypeSerializer(serializers.HyperlinkedModelSerializer):
 
     class Meta:
         model = ProductType
-        fields = ('category')
+        fields = '__all__'
 
 class OrderSerializer(serializers.HyperlinkedModelSerializer):
 

--- a/bangazon/bangazon_api/views.py
+++ b/bangazon/bangazon_api/views.py
@@ -1,6 +1,6 @@
 from django.shortcuts import render
-from bangazon_api.models import PaymentType, Customer, Order, Product
-from bangazon_api.serializers import PaymentTypeSerializer, CustomerSerializer, OrderSerializer, ProductSerializer
+from bangazon_api.models import PaymentType, Customer, Order, Product, ProductType
+from bangazon_api.serializers import PaymentTypeSerializer, CustomerSerializer, OrderSerializer, ProductSerializer, ProductTypeSerializer
 from rest_framework import viewsets
 
 
@@ -39,3 +39,14 @@ class OrderViewSet(viewsets.ModelViewSet):
 
 	queryset = Order.objects.all().order_by('-customer')
 	serializer_class = OrderSerializer
+
+class ProductTypeViewSet(viewsets.ModelViewSet):
+
+    """
+    API endpoint that allows Product Types to be viewed or edited.
+    @rtwhitfield84
+
+    """
+
+    queryset = ProductType.objects.all().order_by('-category')
+    serializer_class = ProductTypeSerializer


### PR DESCRIPTION
## Description
-product types view
Created the product types view in order for client to be able to view this resource. Had to update the product type serializer Meta class fields property to include  dunder all as the single category field was returning an error. dunder all specifies that all model fields will be included.
All views should now be complete.

-product types url
Updated the  url routing to support the new product type view

## Related Issue
issues: -product types view #48
-product types url #47 

## Motivation and Context
 Why is this change required? What problem does it solve? 

## How Has This Been Tested?
tested by running server and making sure user could navigate to all views

## Steps to Test
run server and navigate


## Types of changes
 What types of changes does your code introduce? Put an \`x\` in all the boxes that apply: 
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
 Go over all the following points, and put an \`x\` in all the boxes that apply. 
 If you're unsure about any of these, don't hesitate to ask. We're here to help! 
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
