### PR TITLE
updated customer field to allow second address to be blank

### DIFF
--- a/bangazon/bangazon_api/models.py
+++ b/bangazon/bangazon_api/models.py
@@ -6,7 +6,7 @@ class Customer(models.Model):
 	last_name = models.CharField(max_length=50)
 	account_created = models.DateTimeField(auto_now_add=True)
 	address_1 = models.CharField(max_length=128)
-	address_2 = models.CharField(max_length=128)
+	address_2 = models.CharField(max_length=128, blank=True)
 	city = models.CharField(max_length=20)
 	state = models.CharField(max_length=20)
 	zip_code = models.CharField(max_length=10)


### PR DESCRIPTION

## Description
Discovered a bug where user address field 2 could not be left blank.

## Related Issue
issue: #69 

## Motivation and Context
If a user does not have a second address line then this field is superfluous and returns an error upon creation. Yet necessary if they have do have a second address line.

## How Has This Been Tested?
I tested this in the browser by creating anew user and leaving the address field 2 blank and it worked.
## Steps to Test
create a customer and leave address line 2 blank.

## Types of changes
 What types of changes does your code introduce? Put an \`x\` in all the boxes that apply: 
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
 Go over all the following points, and put an \`x\` in all the boxes that apply. 
 If you're unsure about any of these, don't hesitate to ask. We're here to help! 
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
