### PR TITLE
Corrected initData error

### DIFF
--- a/bangazon/bangazon_api/fixtures/initData.json
+++ b/bangazon/bangazon_api/fixtures/initData.json
@@ -1,81 +1,4 @@
 [{
-    "model": "contenttypes.contenttype",
-    "pk": 1,
-    "fields": {
-        "app_label": "admin",
-        "model": "logentry"
-    }
-}, {
-    "model": "contenttypes.contenttype",
-    "pk": 2,
-    "fields": {
-        "app_label": "auth",
-        "model": "permission"
-    }
-}, {
-    "model": "contenttypes.contenttype",
-    "pk": 3,
-    "fields": {
-        "app_label": "auth",
-        "model": "user"
-    }
-}, {
-    "model": "contenttypes.contenttype",
-    "pk": 4,
-    "fields": {
-        "app_label": "auth",
-        "model": "group"
-    }
-}, {
-    "model": "contenttypes.contenttype",
-    "pk": 5,
-    "fields": {
-        "app_label": "contenttypes",
-        "model": "contenttype"
-    }
-}, {
-    "model": "contenttypes.contenttype",
-    "pk": 6,
-    "fields": {
-        "app_label": "sessions",
-        "model": "session"
-    }
-}, {
-    "model": "contenttypes.contenttype",
-    "pk": 7,
-    "fields": {
-        "app_label": "bangazon_api",
-        "model": "customer"
-    }
-}, {
-    "model": "contenttypes.contenttype",
-    "pk": 8,
-    "fields": {
-        "app_label": "bangazon_api",
-        "model": "order"
-    }
-}, {
-    "model": "contenttypes.contenttype",
-    "pk": 9,
-    "fields": {
-        "app_label": "bangazon_api",
-        "model": "paymenttype"
-    }
-}, {
-    "model": "contenttypes.contenttype",
-    "pk": 10,
-    "fields": {
-        "app_label": "bangazon_api",
-        "model": "product"
-    }
-}, {
-    "model": "contenttypes.contenttype",
-    "pk": 11,
-    "fields": {
-        "app_label": "bangazon_api",
-        "model": "producttype"
-    }
-}, {
     "model": "sessions.session",
     "pk": "41fmsbmhz48jnoneugzze3rh1x85q6ht",
     "fields": {
@@ -111,7 +34,9 @@
         "last_name": "Chemsak",
         "account": "1234567891234567",
         "expiration_date": "2017-01-25",
-        "ccv": "123"
+        "ccv": "123",
+        "payment_type_name": "VISA",
+        "category": "Debit Card"
     }
 }, {
     "model": "bangazon_api.order",


### PR DESCRIPTION
## Description
1. Removed all fields with "model": "contenttypes.contenttype", which was causing the error.

2. InitData was created before adding payment type name and category, so the following fields were added to json file:
 "payment_type_name": "VISA",
 "category": "Debit"

## Related Issue
[#71](https://github.com/Ambiguous-Squids/bangazon-api/issues/71)

## Motivation and Context
Initial data was not populating.

## How Has This Been Tested?
ran $ python manage.py loaddata initData.json, which did not produce an error, and output:
Installed 52 object(s) from 1 fixture(s)

logged in to the app, and verified that the data was there.

## Steps to Test
run $ python manage.py loaddata initData.json and check your app


## Types of changes
 What types of changes does your code introduce? Put an \`x\` in all the boxes that apply: 
- [x\] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
 Go over all the following points, and put an \`x\` in all the boxes that apply. 
 If you're unsure about any of these, don't hesitate to ask. We're here to help! 
- [x\] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
