### PR TITLE
customer view authorization

### DIFF
--- a/bangazon/bangazon/settings.py
+++ b/bangazon/bangazon/settings.py
@@ -31,13 +31,12 @@ ALLOWED_HOSTS = []
 STATIC_URL = '/static/'
 
 REST_FRAMEWORK = {
-    'DEFAULT_AUTHENTICATION_CLASSES': (
-        'rest_framework.authentication.SessionAuthentication',
-    ),
-    'DEFAULT_PERMISSION_CLASSES': (
-        'rest_framework.permissions.IsAuthenticatedOrReadOnly',
-    ),
+    'PAGE_SIZE': 10,
+    # 'DEFAULT_PERMISSION_CLASSES': (
+    #    'rest_framework.permissions.IsAuthenticated',
+    # ),
 }
+
 # Application definition
 
 INSTALLED_APPS = [

--- a/bangazon/bangazon/settings.py
+++ b/bangazon/bangazon/settings.py
@@ -32,9 +32,9 @@ STATIC_URL = '/static/'
 
 REST_FRAMEWORK = {
     'PAGE_SIZE': 10,
-    # 'DEFAULT_PERMISSION_CLASSES': (
-    #    'rest_framework.permissions.IsAuthenticated',
-    # ),
+    'DEFAULT_PERMISSION_CLASSES': (
+       'rest_framework.permissions.IsAuthenticated',
+    ),
 }
 
 # Application definition

--- a/bangazon/bangazon/urls.py
+++ b/bangazon/bangazon/urls.py
@@ -5,11 +5,11 @@ from rest_framework import routers
 
 router = routers.DefaultRouter()
 router.register(r'products', views.ProductViewSet)
-# router.register(r'customers', views.CustomerViewSet)
+router.register(r'customers', views.CustomerViewSet)
 router.register(r'orders', views.OrderViewSet)
 router.register(r'payment_types', views.PaymentTypeViewSet)
 router.register(r'product_types', views.ProductTypeViewSet)
-router.register(r'customers', views.UserViewSet)
+# router.register(r'customers', views.UserViewSet)
 
 
 urlpatterns = [

--- a/bangazon/bangazon/urls.py
+++ b/bangazon/bangazon/urls.py
@@ -5,10 +5,11 @@ from rest_framework import routers
 
 router = routers.DefaultRouter()
 router.register(r'products', views.ProductViewSet)
-router.register(r'customers', views.CustomerViewSet)
+# router.register(r'customers', views.CustomerViewSet)
 router.register(r'orders', views.OrderViewSet)
 router.register(r'payment_types', views.PaymentTypeViewSet)
 router.register(r'product_types', views.ProductTypeViewSet)
+router.register(r'customers', views.UserViewSet)
 
 
 urlpatterns = [

--- a/bangazon/bangazon/urls.py
+++ b/bangazon/bangazon/urls.py
@@ -9,7 +9,6 @@ router.register(r'customers', views.CustomerViewSet)
 router.register(r'orders', views.OrderViewSet)
 router.register(r'payment_types', views.PaymentTypeViewSet)
 router.register(r'product_types', views.ProductTypeViewSet)
-# router.register(r'customers', views.UserViewSet)
 
 
 urlpatterns = [

--- a/bangazon/bangazon_api/serializers.py
+++ b/bangazon/bangazon_api/serializers.py
@@ -1,6 +1,6 @@
+from django.contrib.auth.models import User
 from rest_framework import serializers
 from bangazon_api import models
-
 
 
 class PaymentTypeSerializer(serializers.HyperlinkedModelSerializer):
@@ -59,5 +59,23 @@ class CustomerSerializer(serializers.HyperlinkedModelSerializer):
         model = models.Customer
         fields = '__all__'
 
+class UserStaffSerializer(serializers.HyperlinkedModelSerializer):
+    """
+    Create a serializer for users who are staff, and can see all fields
+    @mccordgh
+    """
 
+    class Meta:
+        model = User
+        fields = ('first_name', 'last_name', 'email')
 
+class UserSerializer(serializers.HyperlinkedModelSerializer):
+    """
+    Create a serializer for users who are not staff, and can only view first_name and last_name fields
+    @mccordgh
+    """
+    # customer = CustomerSerializer(many=False, read_only=True)
+
+    class Meta:
+        model = User
+        fields = ('first_name', 'last_name')

--- a/bangazon/bangazon_api/serializers.py
+++ b/bangazon/bangazon_api/serializers.py
@@ -66,8 +66,8 @@ class UserStaffSerializer(serializers.HyperlinkedModelSerializer):
     """
 
     class Meta:
-        model = User
-        fields = ('first_name', 'last_name', 'email')
+        model = models.Customer
+        fields = ('first_name', 'last_name', 'account_created', 'address_1', 'address_2', 'city', 'state', 'zip_code', 'email')
 
 class UserSerializer(serializers.HyperlinkedModelSerializer):
     """
@@ -77,5 +77,5 @@ class UserSerializer(serializers.HyperlinkedModelSerializer):
     # customer = CustomerSerializer(many=False, read_only=True)
 
     class Meta:
-        model = User
+        model = models.Customer
         fields = ('first_name', 'last_name')

--- a/bangazon/bangazon_api/views.py
+++ b/bangazon/bangazon_api/views.py
@@ -1,6 +1,7 @@
 from django.shortcuts import render
 from bangazon_api import serializers, models
 from rest_framework import viewsets
+from django.contrib.auth.models import User
 
 
 
@@ -28,17 +29,22 @@ class CustomerViewSet(viewsets.ModelViewSet):
     -@mccordgh
     """
     queryset = models.Customer.objects.all().order_by('-last_name')
-    serializer_class = serializers.CustomerSerializer
+    queryset = User.objects.all()
+
+    def get_serializer_class(self):
+        if self.request.user.is_staff:
+            return serializers.UserStaffSerializer
+        return serializers.UserSerializer    serializer_class = serializers.CustomerSerializer
 
 
 class OrderViewSet(viewsets.ModelViewSet):
-	"""
-	API endpoint that allows Orders to be viewed or edited.
-	-@asimonia
-	"""
+    """
+    API endpoint that allows Orders to be viewed or edited.
+    -@asimonia
+    """
 
-	queryset = models.Order.objects.all().order_by('-customer')
-	serializer_class = serializers.OrderSerializer
+    queryset = models.Order.objects.all().order_by('-customer')
+    serializer_class = serializers.OrderSerializer
 
 class ProductTypeViewSet(viewsets.ModelViewSet):
 
@@ -50,3 +56,15 @@ class ProductTypeViewSet(viewsets.ModelViewSet):
 
     queryset = models.ProductType.objects.all().order_by('-category')
     serializer_class = serializers.ProductTypeSerializer
+
+class UserViewSet(viewsets.ModelViewSet):
+    """
+    User view for non-staff users
+    @mccordgh
+    """
+    queryset = User.objects.all()
+
+    def get_serializer_class(self):
+        if self.request.user.is_staff:
+            return serializers.UserStaffSerializer
+        return serializers.UserSerializer

--- a/bangazon/bangazon_api/views.py
+++ b/bangazon/bangazon_api/views.py
@@ -4,7 +4,6 @@ from rest_framework import viewsets
 from django.contrib.auth.models import User
 
 
-
 class PaymentTypeViewSet(viewsets.ModelViewSet):
     """
     Creates PaymentType View
@@ -29,12 +28,11 @@ class CustomerViewSet(viewsets.ModelViewSet):
     -@mccordgh
     """
     queryset = models.Customer.objects.all().order_by('-last_name')
-    queryset = User.objects.all()
 
     def get_serializer_class(self):
         if self.request.user.is_staff:
             return serializers.UserStaffSerializer
-        return serializers.UserSerializer    serializer_class = serializers.CustomerSerializer
+        return serializers.UserSerializer    
 
 
 class OrderViewSet(viewsets.ModelViewSet):
@@ -56,15 +54,3 @@ class ProductTypeViewSet(viewsets.ModelViewSet):
 
     queryset = models.ProductType.objects.all().order_by('-category')
     serializer_class = serializers.ProductTypeSerializer
-
-class UserViewSet(viewsets.ModelViewSet):
-    """
-    User view for non-staff users
-    @mccordgh
-    """
-    queryset = User.objects.all()
-
-    def get_serializer_class(self):
-        if self.request.user.is_staff:
-            return serializers.UserStaffSerializer
-        return serializers.UserSerializer


### PR DESCRIPTION
## Description
Made staff or admin status required to view more than customer first/last name.

## Motivation and Context
Sensitive customer data was able to be seen by anyone regardless of admin/staff status.
Setup Two serializers, one for staff and admin and one for regular users, to help secure customer data.

## How Has This Been Tested?
Created a regular non-staff / non-admin user, and after logging in I could only see first_name and last_name fields in /customers/
Created an admin account, and after logging in I could see all fields in /customers/

## Steps to Test
* git fetch
* git checkout mm-customer-auth-serializer
* $ python manage.py runserver
* login to admin panel at http://localhost:8000/admin
* navigate to http://localhost:8000/customers/
* make sure you can view all fields ('first_name', 'last_name', 'account_created', 'address_1', 'address_2',         
    'city', 'state', 'zip_code', 'email')
* go to admin panel and click +Add User
* create a regular user (no staff or admin permissions)
* log out
* log in with newly created regular user
* navigate to http://localhost:8000/customers/
* make sure you can only see first_name and last_name fields
* log out

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
